### PR TITLE
Specify defualt host 127.0.0.0 instead of 0.0.0.0

### DIFF
--- a/middleman-core/lib/middleman-core/application.rb
+++ b/middleman-core/lib/middleman-core/application.rb
@@ -69,7 +69,7 @@ module Middleman
 
     # Which host preview should start on.
     # @return [Fixnum]
-    config.define_setting :host, '0.0.0.0', 'The preview server host'
+    config.define_setting :host, '127.0.0.0', 'The preview server host'
 
     # Which port preview should start on.
     # @return [Fixnum]


### PR DESCRIPTION
IP addresses beginning with 0 are not valid. For local host 127 should be used instead.